### PR TITLE
Use subscription helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/events",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/events",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/jasmine": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/events",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Sync and async event emitters",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/src/AsyncEventEmitter.ts
+++ b/src/AsyncEventEmitter.ts
@@ -1,4 +1,4 @@
-
+import {AsyncSubscription} from './Subscription';
 
 function wrapAsyncListener(asyncListener: (...arg: any) => Promise<void>,
                            error?: (err: Error) => void,
@@ -86,8 +86,9 @@ class AsyncEventEmitter<T> {
         }
     }
 
-    subscribe(next: (value: T) => Promise<void>, error?: (err: Error) => void, complete?: () => void): void {
+    subscribe(next: (value: T) => Promise<void>, error?: (err: Error) => void, complete?: () => void): AsyncSubscription {
         this.listeners.push(wrapAsyncListener(next, error, complete));
+        return new AsyncSubscription(this, next);
     }
 
     subscribeOnce(next: (value: T) => Promise<void>, error?: (err: Error) => void, complete?: () => void): void {

--- a/src/AsyncSeriesEventEmitter.ts
+++ b/src/AsyncSeriesEventEmitter.ts
@@ -1,4 +1,4 @@
-
+import {AsyncSubscription} from './Subscription';
 
 function wrapAsyncListener(asyncListener: (...arg: any) => Promise<void>) {
     const wrapListener = function() {
@@ -65,8 +65,9 @@ class AsyncSeriesEventEmitter<T> {
         }
     }
 
-    subscribe(next: (value: T) => Promise<void>): void {
+    subscribe(next: (value: T) => Promise<void>): AsyncSubscription {
         this.listeners.push(wrapAsyncListener(next));
+        return new AsyncSubscription(this, next);
     }
 
     subscribeOnce(next: (value: T) => Promise<void>): void {

--- a/src/Subscription.spec.ts
+++ b/src/Subscription.spec.ts
@@ -1,0 +1,86 @@
+import {AsyncEventEmitter} from './AsyncEventEmitter';
+import {SyncSeriesEventEmitter} from './SyncSeriesEventEmitter';
+import {AsyncSeriesEventEmitter} from './AsyncSeriesEventEmitter';
+
+describe('Subscription', () => {
+
+    it('should use AsyncSubscription.unsubscribe()', async ()=> {
+        class MyClass {
+            public readonly load = new AsyncEventEmitter<{value: number}>();
+        }
+        const newItem = new MyClass();
+        newItem.load.subscribe(async (event: { value: number }) => {
+            setTimeout(() => {
+                event.value += 1;
+            }, 400);
+        });
+        const second = newItem.load.subscribe(async (event: { value: number }) => {
+            setTimeout(() => {
+                event.value += 1;
+            }, 500);
+        });
+        const eventArgs = {
+            value: 100
+        }
+        newItem.load.emit(eventArgs);
+        expect(eventArgs.value).toBe(100);
+        await new Promise((resolve) => {
+            setTimeout(() => {
+                expect(eventArgs.value).toBe(102);
+                return resolve(true);
+            }, 1000);
+        });
+
+        second.unsubscribe();
+        newItem.load.emit(eventArgs);
+        await new Promise((resolve) => {
+            setTimeout(() => {
+                expect(eventArgs.value).toBe(103);
+                return resolve(true);
+            }, 1000);
+        });
+    });
+
+    it('should use SyncSubscription.unsubscribe()', async ()=> {
+        class MyClass {
+            public readonly load = new SyncSeriesEventEmitter<{value: number}>();
+        }
+        const newItem = new MyClass();
+        newItem.load.subscribe((event: { value: number }) => {
+            event.value += 1;
+        });
+        const second = newItem.load.subscribe((event: { value: number }) => {
+            event.value += 2;
+        });;
+        const eventArgs = {
+            value: 1
+        }
+        newItem.load.emit(eventArgs);
+        expect(eventArgs.value).toBe(4);
+        second.unsubscribe();
+        newItem.load.emit(eventArgs);
+        expect(eventArgs.value).toBe(5);
+    });
+
+    it('should use AsyncSubscription.unsubscribe()', async ()=> {
+        class MyClass {
+            public readonly load = new AsyncSeriesEventEmitter<{value: number}>();
+        }
+        const newItem = new MyClass();
+        newItem.load.subscribe(async (event: { value: number }) => {
+            event.value += 1;
+        });
+        const second = newItem.load.subscribe(async (event: { value: number }) => {
+            event.value += 2;
+        });;
+        const eventArgs = {
+            value: 1
+        }
+        await newItem.load.emit(eventArgs);
+        expect(eventArgs.value).toBe(4);
+        second.unsubscribe();
+        newItem.load.emit(eventArgs);
+        expect(eventArgs.value).toBe(5);
+    });
+
+});

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -1,0 +1,24 @@
+
+
+class AsyncSubscription {
+    constructor(private emitter: { unsubscribe(listener: (value: any) => Promise<void>): void }, private listener: (value: any) => Promise<void>) {
+        //
+    }
+    unsubscribe() {
+        this.emitter.unsubscribe(this.listener);
+    }
+}
+
+class SyncSubscription {
+    constructor(private emitter: { unsubscribe(listener: (value: any) => void): void }, private listener: (value: any) => void) {
+        //
+    }
+    unsubscribe() {
+        this.emitter.unsubscribe(this.listener);
+    }
+}
+
+export {
+    AsyncSubscription,
+    SyncSubscription
+}

--- a/src/SyncSeriesEventEmitter.ts
+++ b/src/SyncSeriesEventEmitter.ts
@@ -1,3 +1,5 @@
+import {SyncSubscription} from './Subscription';
+
 function wrapSyncListener<T>(syncListener: (arg: T) => void): (arg: T) => void {
     // tslint:disable-next-line:only-arrow-functions
     const wrapListener = function() {
@@ -45,8 +47,9 @@ class SyncSeriesEventEmitter<T> {
         }
     }
 
-    subscribe(next: (value: T) => void): void {
+    subscribe(next: (value: T) => void): SyncSubscription {
         this.listeners.push(wrapSyncListener(next));
+        return new SyncSubscription(this, next);
     }
 
     subscribeOnce(next: (value: T) => void): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './Subscription';
 export * from './SyncSeriesEventEmitter';
 export * from './AsyncSeriesEventEmitter';
 export * from './AsyncEventEmitter';


### PR DESCRIPTION
This PR implements event subscription helpers for unsubscribing an event listener e.g.

```
const subscription = item.load.subscribe(async (event: { value: number }) => {
            setTimeout(() => {
                event.value += 1;
            }, 500);
        });
...
subscription.unsubscribe();
```