### PR TITLE
handle process event emitter events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/events",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/events",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Sync and async event emitters",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/platform-server/register/src/index.ts
+++ b/platform-server/register/src/index.ts
@@ -2,9 +2,11 @@ import cluster from 'cluster';
 if (cluster.isMaster || cluster.isPrimary) {
     cluster.on('message', (worker: any, data: any) => {
         if (cluster.workers) {
-            Object.keys(cluster.workers).forEach((id) => {
-                cluster.workers[id].send(data);
-             });
+            if (data && data.target === 'ProcessEventEmitter') {
+                Object.keys(cluster.workers).forEach((id) => {
+                    cluster.workers[id].send(data);
+                });
+            }
         }
     });
 }


### PR DESCRIPTION
This PR enables the handling of events derived only from `ProcessEventEmitter`. Other process events are being omitted.